### PR TITLE
Add restart command to docker-compose.yml

### DIFF
--- a/MQTT/docker-compose.yml
+++ b/MQTT/docker-compose.yml
@@ -5,6 +5,7 @@ version: "3"
 services:
   broker:
     image: eclipse-mosquitto
+    restart: always
     #volumes:
     #  - "./mosquitto/config:/mosquitto/config"
     #  - "./mosquitto/data:/mosquitto/data"
@@ -19,6 +20,7 @@ services:
     depends_on:
       - broker #use "broker" as the mqtt-addres in node-red
     image: my-node-red
+    restart: always
     volumes:
       - "./node-red:/data"
     ports:


### PR DESCRIPTION
Adding the restart command is useful to restart the container when it
crashes for some reason, this could insure that the service is online and running.